### PR TITLE
Fix: Parser crash on routes with empty lines and incorrect note assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+playground

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Mount Route Planner
+
+## [v0.3.0](https://github.com/Deathwing/Mount-Route-Planner/releases/tag/v0.3.0) (2025-07-07)
+[Full Changelog](https://github.com/Deathwing/Mount-Route-Planner/commits/v0.3.0) [Previous Releases](https://github.com/Deathwing/Mount-Route-Planner/releases)
+
+### Changes
+- Waypoints are now saved only within the session, applies to both TomTom and Blizzard's waypoint system.
+- TomTom will no longer print out debug messages about waypoints.
+- TomTom is now enabled by default. You can disable it in the settings.
+
+### Bug Fixes
+- Player's TomTom waypoints will no longer be removed by Mount Route Planner in some cases.
+
+## [v0.2.0](https://github.com/Deathwing/Mount-Route-Planner/releases/tag/v0.2.0) (2025-07-07)
+[Full Changelog](https://github.com/Deathwing/Mount-Route-Planner/commits/v0.2.0) [Previous Releases](https://github.com/Deathwing/Mount-Route-Planner/releases)
+
+### Changes
+- Added russian translation (thanks to ZamestoTV)
+- Added german translation
+- Overall clean up of the project (removed a lot of global vars…)
+
+### Bug Fixes
+- Fixed an issue preventing data from Firefox to be imported correctly
+- Fixed an issue where Boss names didn't match correctly (i.e. ‘Spine of Deathwing’ for ‘Deathwing’)
+- Fixed multiple issues related to clients not running the English locale (no icons shown, item actions were not working, mounts not found, etc.)

--- a/MRP.lua
+++ b/MRP.lua
@@ -1,7 +1,7 @@
-MRP = MRP or {}
-MRP.Data = MRP.Data or {}
-MRP.UI = MRP.UI or {}
-MRP.Parser = MRP.Parser or {}
+-- MRP.lua
+local _, MRP = ...
+
+local L = MRP.L
 
 function MRP_Clear()
     MRP.parsedSteps = {}
@@ -32,7 +32,6 @@ function MRP_Parse(text)
     end
 
     MRP_NextStep()
-
 end
 
 function MRP_PreviousStep()
@@ -66,9 +65,9 @@ function MRP_NextStep()
     repeat
         MRP.currentIndex = MRP.currentIndex + 1
         local step = MRP.parsedSteps[MRP.currentIndex]
-    until not ( MRP_DB.autoSkip
-             and step
-             and MRP_ShouldSkipStep(step) )
+    until not (MRP_DB.autoSkip
+            and step
+            and MRP_ShouldSkipStep(step))
 
     if UnitFactionGroup("player") == "Alliance" then
         MRP_DB.currentIndex_A = MRP.currentIndex
@@ -79,24 +78,6 @@ function MRP_NextStep()
     MRP.UI:UpdateDisplay()
 end
 
-local f = CreateFrame("Frame")
-f:RegisterEvent("PLAYER_LOGIN")
-f:SetScript("OnEvent", function()
-    if UnitFactionGroup("player") == "Alliance" then
-        if MRP_DB.parsedSteps_A then
-            MRP.parsedSteps = MRP_DB.parsedSteps_A
-            MRP.currentIndex = MRP_DB.currentIndex_A or 1
-            MRP_CheckCurrentStepComplete(false)
-        end
-    else
-        if MRP_DB.parsedSteps_H then
-            MRP.parsedSteps = MRP_DB.parsedSteps_H
-            MRP.currentIndex = MRP_DB.currentIndex_H or 1
-            MRP_CheckCurrentStepComplete(false)
-        end
-    end
-end)
-
 local specialMountIds = {
     ["Deathcharger's Reins"] = 69,
     ["Blue Qiraji Crystal"] = 117,
@@ -104,23 +85,94 @@ local specialMountIds = {
     ["Yellow Qiraji Crystal"] = 119,
     ["Green Qiraji Crystal"] = 120,
     ["Fiery Warhorse's Reins"] = 168,
+    ["Ashes of Al'ar"] = 183,
+    ["Raven Lord"] = 185,
+    ["Swift White Hawkstrider"] = 213,
+    ["Azure Drake"] = 246,
+    ["Blue Drake"] = 247,
+    ["Bronze Drake"] = 248,
+    ["Twilight Drake"] = 250,
+    ["Black Drake"] = 253,
+    ["Blue Proto-Drake"] = 264,
+    ["Mimiron's Head"] = 304,
+    ["Onyxian Drake"] = 349,
     ["Invincible's Reins"] = 363,
+    ["Drake of the North Wind"] = 395,
+    ["Drake of the South Wind"] = 396,
+    ["Vitreous Stone Drake"] = 397,
+    ["Armored Razzashi Raptor"] = 410,
+    ["Swift Zulian Panther"] = 411,
     ["Egg of Millagazor"] = 415,
+    ["Amani Battle Bear"] = 419,
+    ["Flametalon of Alysrazor"] = 425,
+    ["Blazing Drake"] = 442,
+    ["Life-Binder's Handmaiden"] = 444,
+    ["Experiment 12-B"] = 445,
     ["Reins of the Heavenly Onyx Cloud Serpent"] = 473,
     ["Reins of the Astral Cloud Serpent"] = 478,
     ["Son of Galleon's Saddle"] = 515,
+    ["Spawn of Horridon"] = 531,
     ["Reins of the Cobalt Primordial Direhorn"] = 533,
     ["Reins of the Thundering Cobalt Cloud Serpent"] = 542,
+    ["Clutch of Ji-Kun"] = 543,
+    ["Kor'kron Juggernaut"] = 559,
+    ["Ironhoof Destroyer"] = 613,
     ["Fiendish Hellfire Core"] = 633,
+    ["Solar Spirehawk"] = 634,
+    ["Felsteel Annihilator"] = 751,
+    ["Infinite Timereaver"] = 781,
     ["Living Infernal Core"] = 791,
     ["Midnight's Eternal Reins"] = 875,
+    ["Smoldering Ember Wyrm"] = 883,
+    ["Abyss Worm"] = 899,
+    ["Shackled Ur'zul"] = 954,
+    ["Antoran Charhound"] = 971,
     ["Sharkbait's Favorite Crackers"] = 995,
     ["Mummified Raptor Skull"] = 1040,
-    ["Underrot Crawg Harness"] = 1053
+    ["Underrot Crawg Harness"] = 1053,
+    ["G.M.O.D."] = 1217,
+    ["Glacial Tidestorm"] = 1219,
+    ["Aerial Unit R-21/X"] = 1227,
+    ["Mechagon Peacekeeper"] = 1252,
+    ["Ny'alotha Allseer"] = 1293,
+    ["Marrowfang"] = 1406,
+    ["Vengeance"] = 1471,
+    ["Cartel Master's Gearglider"] = 1481,
+    ["Sanctum Gloomcharger"] = 1500,
+    ["Zereth Overseer"] = 1587,
+    ["Anu'relos, Flame's Guidance"] = 1818,
+    ["Stonevault Mechsuit"] = 2119,
+    ["Wick"] = 2204,
+    ["Sureki Skyrazor"] = 2219,
+    ["Ascendant Skyrazor"] = 2223,
+    ["The Big G"] = 2487,
+    ["Prototype A.S.M.R."] = 2507
+}
+
+local specialFactionMountIds = {
+    ["Alliance"] = {
+        ["Grand Black War Mammoth"] = 286,
+    },
+    ["Horde"] = {
+        ["Grand Black War Mammoth"] = 287
+    }
 }
 
 local mountIconCache = {}
 local mountMissingReportedCache = {}
+
+function MRP_GetSpecialMountId(name)
+    if specialMountIds[name] then
+        return specialMountIds[name]
+    end
+
+    local faction = UnitFactionGroup("player")
+    if faction and specialFactionMountIds[faction] and specialFactionMountIds[faction][name] then
+        return specialFactionMountIds[faction][name]
+    end
+
+    return nil
+end
 
 function MRP_GetMountIconByName(name)
     if not name then return nil end
@@ -129,8 +181,9 @@ function MRP_GetMountIconByName(name)
         return mountIconCache[name]
     end
 
-    if specialMountIds[name] then
-        local icon = select(3, C_MountJournal.GetMountInfoByID(specialMountIds[name]))
+    local specialMountId = MRP_GetSpecialMountId(name)
+    if specialMountId then
+        local icon = select(3, C_MountJournal.GetMountInfoByID(specialMountId))
         if icon then
             mountIconCache[name] = icon
             return icon
@@ -141,7 +194,7 @@ function MRP_GetMountIconByName(name)
 
     for i = 1, #mountIds do
         local mountName, _, icon = C_MountJournal.GetMountInfoByID(mountIds[i])
-        if mountName and (mountName == name or mountName:lower():find(name:lower()))  then
+        if mountName and (mountName == name or mountName:lower():find(name:lower())) then
             mountIconCache[name] = icon
             return icon
         end
@@ -159,15 +212,16 @@ end
 function MRP_GetMountCollectedByName(name)
     if not name then return nil end
 
-    if specialMountIds[name] then
-        return select(11, C_MountJournal.GetMountInfoByID(specialMountIds[name]))
+    local specialMountId = MRP_GetSpecialMountId(name)
+    if specialMountId then
+        return select(11, C_MountJournal.GetMountInfoByID(specialMountId))
     end
 
     local mountIds = C_MountJournal.GetMountIDs()
 
     for i = 1, #mountIds do
         local mountName, _, _, _, _, _, _, _, _, _, collected = C_MountJournal.GetMountInfoByID(mountIds[i])
-        if mountName and (mountName == name or mountName:lower():find(name:lower()))  then
+        if mountName and (mountName == name or mountName:lower():find(name:lower())) then
             return collected
         end
     end
@@ -191,8 +245,8 @@ function MRP_IsBossDead(boss, instance)
             if instanceName and locked and instanceName:lower():find(instanceNameTarget) then
                 local numEncounters = select(9, GetSavedInstanceInfo(i))
                 for j = 1, numEncounters do
-                    local boss, _, isKilled = GetSavedInstanceEncounterInfo(i, j)
-                    if boss and (boss == bossName or boss:lower():find(bossName)) then
+                    local encounterName, _, isKilled = GetSavedInstanceEncounterInfo(i, j)
+                    if encounterName and (encounterName == bossName or encounterName:lower() == bossName) then
                         return isKilled
                     end
                 end
@@ -201,8 +255,8 @@ function MRP_IsBossDead(boss, instance)
     end
 
     for i = 1, GetNumSavedWorldBosses() do
-        local name = GetSavedWorldBossInfo(i)
-        if name and (name == bossName or name:lower():find(bossName)) then
+        local worldBossName = GetSavedWorldBossInfo(i)
+        if worldBossName and (worldBossName == bossName or worldBossName:lower() == bossName) then
             return true
         end
     end
@@ -224,7 +278,7 @@ function MRP_IsCorrectDifficulty(neededDiffString)
         end
 
         if not selectedDiffID or selectedDiffID == 0 then
-            selectedDiffID = GetLegacyRaidDifficulty()
+            selectedDiffID = GetLegacyRaidDifficultyID()
         end
 
         return MRP_MatchesDifficulty(neededDiffString, selectedDiffID)
@@ -291,7 +345,7 @@ function MRP_ShouldSkipStep(step)
         return allImportantDead
     elseif step.item or step.flyTo or step.flightPath or step.portal or step.walkTo or step.teleport or step.hearthstone then
         return inZone(step.item or step.flyTo or step.flightPath or step.portal or step.walkTo or step.teleport or
-                          step.hearthstone)
+            step.hearthstone)
     end
 
     return false
@@ -301,7 +355,7 @@ function MRP_CheckCurrentStepComplete(force)
     if MRP.parsedSteps == nil or #MRP.parsedSteps == 0 then
         return
     end
-    
+
     local step = MRP.parsedSteps[MRP.currentIndex]
     if step and (force or (MRP_DB.autoAdvance and MRP_ShouldSkipStep(step))) then
         MRP_NextStep()
@@ -360,7 +414,6 @@ tomtomCheckbox:SetScript("OnEnter", function(self)
     GameTooltip:AddLine(L["This will create waypoints for each step in your route."], 1, 1, 1)
     GameTooltip:AddLine(L["You must have TomTom installed for this to work."], 1, 0.5, 0.5)
     GameTooltip:AddLine(L["You can toggle this setting at any time."], 0.5, 1, 0.5)
-    GameTooltip:AddLine(L["Note: TomTom will print messages in chat occasionally."], 1, 1, 0.5)
     GameTooltip:Show()
 end)
 
@@ -394,18 +447,14 @@ SlashCmdList["MOUNTROUTEPLANNER"] = function(msg)
 
     if not cmd or cmd == "" then
         MRP.UI:ShowHide()
-
     elseif cmd == "reset" then
         MRP_Clear()
-
     elseif cmd == "settings" then
         MRP_OpenSettings()
-
     elseif cmd == "tomtom" and (arg1 == "on" or arg1 == "off") then
         MRP_DB = MRP_DB or {}
         MRP_DB.useTomTom = (arg1 == "on")
         print(string.format(L["|cff00ff00[MRP]|r TomTom usage is now: %s"], (MRP_DB.useTomTom and L["|cff00ff00ENABLED|r"] or L["|cffff0000DISABLED|r"])))
-
     else
         print(L["|cffffd200Usage:|r"])
         print(L[" - /mrp → Toggle Mount Route Planner UI"])
@@ -414,3 +463,22 @@ SlashCmdList["MOUNTROUTEPLANNER"] = function(msg)
         print(L[" - /mrp tomtom on|off → Enable or disable TomTom integration"])
     end
 end
+
+local f = CreateFrame("Frame")
+f:RegisterEvent("PLAYER_LOGIN")
+f:SetScript("OnEvent", function()
+    tomtomCheckbox:SetChecked(MRP_DB.useTomTom)
+    if UnitFactionGroup("player") == "Alliance" then
+        if MRP_DB.parsedSteps_A then
+            MRP.parsedSteps = MRP_DB.parsedSteps_A
+            MRP.currentIndex = MRP_DB.currentIndex_A or 1
+            MRP_CheckCurrentStepComplete(false)
+        end
+    else
+        if MRP_DB.parsedSteps_H then
+            MRP.parsedSteps = MRP_DB.parsedSteps_H
+            MRP.currentIndex = MRP_DB.currentIndex_H or 1
+            MRP_CheckCurrentStepComplete(false)
+        end
+    end
+end)

--- a/MRP_DB.lua
+++ b/MRP_DB.lua
@@ -1,37 +1,10 @@
-MRP_DB = MRP_DB or {
+-- MRP_DB.lua
+MRP_DB = {
     parsedSteps_A = {},
     currentIndex_A = 0,
     parsedSteps_H = {},
     currentIndex_H = 0,
     autoSkip = true,
     autoAdvance = true,
-    useTomTom = false,
+    useTomTom = true,
 }
-
-if not MRP_DB.parsedSteps_A then
-    MRP_DB.parsedSteps_A = {}
-end
-
-if not MRP_DB.currentIndex_A then
-    MRP_DB.currentIndex_A = 0
-end
-
-if not MRP_DB.parsedSteps_H then
-    MRP_DB.parsedSteps_H = {}
-end
-
-if not MRP_DB.currentIndex_H then
-    MRP_DB.currentIndex_H = 0
-end
-
-if not MRP_DB.autoSkip then
-    MRP_DB.autoSkip = true
-end
-
-if not MRP_DB.autoAdvance then
-    MRP_DB.autoAdvance = true
-end
-
-if not MRP_DB.useTomTom then
-    MRP_DB.useTomTom = false
-end

--- a/MRP_Data.lua
+++ b/MRP_Data.lua
@@ -1,4 +1,6 @@
-MRP = MRP or {}
+-- MRP_Data.lua
+local _, MRP = ...
+
 local Data = {}
 MRP.Data = Data
 

--- a/MRP_Locale.deDE.lua
+++ b/MRP_Locale.deDE.lua
@@ -1,0 +1,112 @@
+-- MRP_Locale.deDE.lua
+local _, MRP = ...
+
+if (GetLocale() ~= "deDE") then
+    return;
+end
+
+MRP.L = {
+    ["Mount Route Planner"] = "Mount Route Planner",
+    ["Left-Click: Toggle Panel"] = "Linksklick: Menu umschalten",
+    ["Drag: Move Button"] = "Ziehen: Schaltfläche verschieben",
+
+    ["Mount Route Planner - Settings"] = "Mount Route Planner - Einstellungen",
+    ["Use TomTom for waypoints"] = "TomTom für Wegpunkte verwenden",
+    ["Enable this to use TomTom for waypoint navigation."] = "Durch das Aktivieren wird TomTom für die Wegpunkt Navigation genutzt",
+    ["This will create waypoints for each step in your route."] = "Dies erstellt Wegpunkte für jeden Schritt in Ihrer Route.",
+    ["You must have TomTom installed for this to work."] = "TomTom muss installiert sein, damit dies funktioniert.",
+    ["You can toggle this setting at any time."] = "Du kannst diese Einstellung jederzeit umschalten.",
+
+    ["|cff00ff00[MRP]|r TomTom usage is now: %s"] = "|cff00ff00[MRP]|r TomTom Nutzung ist jetzt: %s",
+    ["|cff00ff00ENABLED|r"] = "|cff00ff00AKTIVIERT|r",
+    ["|cffff0000DISABLED|r"] = "|cffff0000DEAKTIVIERT|r",
+
+    ["|cffffd200Usage:|r"] = "|cffffd200Benutzung:|r",
+    [" - /mrp → Toggle Mount Route Planner UI"] = " - /mrp → Umschalten des Mount Route Planner UI",
+    [" - /mrp reset → Clears current progress and steps"] = " - /mrp reset → Löscht den aktuellen Fortschritt und die Schritte",
+    [" - /mrp settings → Open addon settings"] = " - /mrp settings → Öffnet die Addon-Einstellungen",
+    [" - /mrp tomtom on|off → Enable or disable TomTom integration"] = " - /mrp tomtom on|off → Aktiviert oder deaktiviert die TomTom-Integration",
+
+    ["Reset Steps"] = "Schritte zurücksetzen",
+    ["Clears current progress and steps"] = "Löscht den aktuellen Fortschritt und die Schritte",
+
+    ["Settings"] = "Einstellungen",
+    ["Open the MRP settings panel"] = "Öffnet das MRP-Einstellungsfenster",
+
+    ["No step loaded."] = "Kein Schritt geladen.",
+
+    ["<< Last"] = "<< Letzter",
+    ["Next >>"] = "Nächster >>",
+
+    ["Step 0 of 0"] = "Schritt 0 von 0",
+    ["Step %d of %d"] = "Schritt %d von %d",
+
+    ["Import Steps"] = "Importieren von Schritten",
+    ["Paste Simple Armory Content"] = "Einfügen von Simple Armory Inhalten",
+
+    ["Import"] = "Importieren",
+    ["Prefill"] = "Vorbefüllen",
+    ["Cancel"] = "Abbrechen",
+
+    ["Automatically fills the input box with preset content based on your faction."] = "Füllt das Eingabefeld automatisch mit vordefinierten Inhalten basierend auf deiner Fraktion.",
+    ["For optimal results import your character's data from Simple Armory."] = "Für optimale Ergebnisse importiere die Daten deines Charakters von Simple Armory.",
+
+    ["To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"] = "Um Inhalte von Simple Armory zu importieren, kopiere den gesamten Inhalt von deinem simplearmory.com-Link und füge ihn in das Eingabefeld ein.\n\nIm Browser öffnen:",
+    ["Close"] = "Schließen",
+
+    ["Run %s"] = "Laufe %s",
+    ["Kill %s"] = "Töte %s",
+    ["Use %s"] = "Benutze %s",
+    ["Fly to %s"] = "Fliege nach %s",
+    ["Take Portal to %s"] = "Nehme das Portal nach %s",
+    ["Use Hearthstone to %s"] = "Benutze den Ruhestein nach %s",
+    ["Use Teleport to %s"] = "Benutze den Teleporter nach %s",
+    ["Take Flight Path to %s"] = "Nehme den Flugpfad nach %s",
+    ["Take Blimp to %s"] = "Nehme das Luftschiff nach %s",
+    ["Walk to %s"] = "Gehe nach %s",
+
+    ["Heroic 25"] = "Heroisch 25",
+    ["Heroic"] = "Heroisch",
+    ["Mythic"] = "Mythisch",
+
+    ["Unknown"] = "Unbekannt",
+    ["Unknown Boss"] = "Unbekannter Boss",
+
+    ["Run the instance on '%s' difficulty to collect all mounts."] = "Laufe die Instanz auf '%s' Schwierigkeit, um alle Reittiere zu sammeln.",
+    ["Your Hearthstone is set to a different location!"] = "Dein Ruhestein ist auf einen anderen Ort gesetzt!",
+
+    ["Mount: %s"] = "Mount: %s",
+    ["You have collected this mount."] = "Du hast dieses Reittier gesammelt.",
+    ["This boss is dead."] = "Dieser Boss ist tot.",
+    ["This boss is still alive."] = "Dieser Boss ist noch am Leben.",
+
+    ["Auto-Skip Steps"] = "Auto-Überspringen von Schritten",
+    ["Automatically skips steps that are already completed."] = "Überspringt automatisch Schritte, die bereits abgeschlossen sind.",
+
+    ["Auto-Advance Steps"] = "Auto-Fortschritt der Schritte",
+    ["Automatically advances to the next step after completing the current one."] = "Automatisch zum nächsten Schritt wechseln, nachdem der aktuelle abgeschlossen ist.",
+
+    ["Instance location not found: '%s', please report it."] = "Instanzstandort nicht gefunden: '%s', bitte melde es.",
+    ["NPC location not found for: '%s', please report it."] = "NPC-Standort nicht gefunden für: '%s', bitte melde es.",
+    ["Item location not found for: '%s', please report it."] = "Gegenstandsstandort nicht gefunden für: '%s', bitte melde es.",
+    ["Portal location not found for: '%s' in '%s', please report it."] = "Portalstandort nicht gefunden für: '%s' in '%s', bitte melde es.",
+    ["Teleport location not found for: '%s', please report it."] = "Teleportstandort nicht gefunden für: '%s', bitte melde es.",
+    ["Blimp location not found for: '%s', please report it."] = "Luftschiffstandort nicht gefunden für: '%s', bitte melde es.",
+    ["Flightmaster location not found for: '%s', please report it."] = "Flugmeisterstandort nicht gefunden für: '%s', bitte melde es.",
+    ["Unknown action: '%s', please report it."] = "Unbekannte Aktion: '%s', bitte melde es.",
+
+    ["Map ID not found for: '%s', please report it."] = "Map ID nicht gefunden für: '%s', bitte melde es.",
+    ["Failed to add TomTom waypoint for: '%s', please report it."] = "Fehler beim Hinzufügen des TomTom-Wegpunkts für: '%s', bitte melde es.",
+    ["Invalid map ID for: '%s', please report it."] = "Ungültige Map ID für: '%s', bitte melde es.",
+    ["Invalid coordinates for: '%s', please report it."] = "Ungültige Koordinaten für: '%s', bitte melde es.",
+    ["Cannot set waypoint on map: '%s', please report it."] = "Kann keinen Wegpunkt auf der Karte setzen: '%s', bitte melde es.",
+
+    ["Mount not found: '%s', please report it."] = "Reittier nicht gefunden: '%s', bitte melde es.",
+    ["Item not found: '%s', please report it."] = "Gegenstand nicht gefunden: '%s', bitte melde es."
+}
+
+setmetatable(MRP.L, {
+    __index = function(t, k)
+        rawset(t, k, k); return k;
+    end
+})

--- a/MRP_Locale.enUS.lua
+++ b/MRP_Locale.enUS.lua
@@ -1,100 +1,108 @@
-L = {}
+-- MRP_Locale.enUS.lua
+local _, MRP = ...
 
-L["Mount Route Planner"] = "Mount Route Planner"
-L["Left-Click: Toggle Panel"] = "Left-Click: Toggle Panel"
-L["Drag: Move Button"] = "Drag: Move Button"
+MRP.L = {
+    ["Mount Route Planner"] = "Mount Route Planner",
+    ["Left-Click: Toggle Panel"] = "Left-Click: Toggle Panel",
+    ["Drag: Move Button"] = "Drag: Move Button",
 
-L["Mount Route Planner - Settings"] = "Mount Route Planner - Settings"
-L["Use TomTom for waypoints"] = "Use TomTom for waypoints"
-L["Enable this to use TomTom for waypoint navigation."] = "Enable this to use TomTom for waypoint navigation."
-L["This will create waypoints for each step in your route."] = "This will create waypoints for each step in your route."
-L["You must have TomTom installed for this to work."] = "You must have TomTom installed for this to work."
-L["You can toggle this setting at any time."] = "You can toggle this setting at any time."
-L["Note: TomTom will print messages in chat occasionally."] = "Note: TomTom will print messages in chat occasionally."
+    ["Mount Route Planner - Settings"] = "Mount Route Planner - Settings",
+    ["Use TomTom for waypoints"] = "Use TomTom for waypoints",
+    ["Enable this to use TomTom for waypoint navigation."] = "Enable this to use TomTom for waypoint navigation.",
+    ["This will create waypoints for each step in your route."] = "This will create waypoints for each step in your route.",
+    ["You must have TomTom installed for this to work."] = "You must have TomTom installed for this to work.",
+    ["You can toggle this setting at any time."] = "You can toggle this setting at any time.",
 
-L["|cff00ff00[MRP]|r TomTom usage is now: %s"] = "|cff00ff00[MRP]|r TomTom usage is now: %s"
-L["|cff00ff00ENABLED|r"] = "|cff00ff00ENABLED|r"
-L["|cffff0000DISABLED|r"] = "|cffff0000DISABLED|r"
+    ["|cff00ff00[MRP]|r TomTom usage is now: %s"] = "|cff00ff00[MRP]|r TomTom usage is now: %s",
+    ["|cff00ff00ENABLED|r"] = "|cff00ff00ENABLED|r",
+    ["|cffff0000DISABLED|r"] = "|cffff0000DISABLED|r",
 
-L["|cffffd200Usage:|r"] = "|cffffd200Usage:|r"
-L[" - /mrp → Toggle Mount Route Planner UI"] = " - /mrp → Toggle Mount Route Planner UI"
-L[" - /mrp reset → Clears current progress and steps"] = " - /mrp reset → Clears current progress and steps"
-L[" - /mrp settings → Open addon settings"] = " - /mrp settings → Open addon settings"
-L[" - /mrp tomtom on|off → Enable or disable TomTom integration"] = " - /mrp tomtom on|off → Enable or disable TomTom integration"
+    ["|cffffd200Usage:|r"] = "|cffffd200Usage:|r",
+    [" - /mrp → Toggle Mount Route Planner UI"] = " - /mrp → Toggle Mount Route Planner UI",
+    [" - /mrp reset → Clears current progress and steps"] = " - /mrp reset → Clears current progress and steps",
+    [" - /mrp settings → Open addon settings"] = " - /mrp settings → Open addon settings",
+    [" - /mrp tomtom on|off → Enable or disable TomTom integration"] = " - /mrp tomtom on|off → Enable or disable TomTom integration",
 
-L["Reset Steps"] = "Reset Steps"
-L["Clears current progress and steps"] = "Clears current progress and steps"
+    ["Reset Steps"] = "Reset Steps",
+    ["Clears current progress and steps"] = "Clears current progress and steps",
 
-L["Settings"] = "Settings"
-L["Open the MRP settings panel"] = "Open the MRP settings panel"
+    ["Settings"] = "Settings",
+    ["Open the MRP settings panel"] = "Open the MRP settings panel",
 
-L["No step loaded."] = "No step loaded."
+    ["No step loaded."] = "No step loaded.",
 
-L["<< Last"] = "<< Last"
-L["Next >>"] = "Next >>"
+    ["<< Last"] = "<< Last",
+    ["Next >>"] = "Next >>",
 
-L["Step 0 of 0"] = "Step 0 of 0"
-L["Step %d of %d"] = "Step %d of %d"
+    ["Step 0 of 0"] = "Step 0 of 0",
+    ["Step %d of %d"] = "Step %d of %d",
 
-L["Import Steps"] = "Import Steps"
-L["Paste Simple Armory Content"] = "Paste Simple Armory Content"
+    ["Import Steps"] = "Import Steps",
+    ["Paste Simple Armory Content"] = "Paste Simple Armory Content",
 
-L["Import"] = "Import"
-L["Prefill"] = "Prefill"
-L["Cancel"] = "Cancel"
+    ["Import"] = "Import",
+    ["Prefill"] = "Prefill",
+    ["Cancel"] = "Cancel",
 
-L["Automatically fills the input box with preset content based on your faction."] = "Automatically fills the input box with preset content based on your faction."
-L["For optimal results import your character's data from Simple Armory."] = "For optimal results import your character's data from Simple Armory."
+    ["Automatically fills the input box with preset content based on your faction."] = "Automatically fills the input box with preset content based on your faction.",
+    ["For optimal results import your character's data from Simple Armory."] = "For optimal results import your character's data from Simple Armory.",
 
-L["To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"] = "To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"
-L["Close"] = "Close"
+    ["To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"] = "To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:",
+    ["Close"] = "Close",
 
-L["Run %s"] = "Run %s"
-L["Kill %s"] = "Kill %s"
-L["Use %s"] = "Use %s"
-L["Fly to %s"] = "Fly to %s"
-L["Take Portal to %s"] = "Take Portal to %s"
-L["Use Hearthstone to %s"] = "Use Hearthstone to %s"
-L["Use Teleport to %s"] = "Use Teleport to %s"
-L["Take Flight Path to %s"] = "Take Flight Path to %s"
-L["Take Blimp to %s"] = "Take Blimp to %s"
-L["Walk to %s"] = "Walk to %s"
+    ["Run %s"] = "Run %s",
+    ["Kill %s"] = "Kill %s",
+    ["Use %s"] = "Use %s",
+    ["Fly to %s"] = "Fly to %s",
+    ["Take Portal to %s"] = "Take Portal to %s",
+    ["Use Hearthstone to %s"] = "Use Hearthstone to %s",
+    ["Use Teleport to %s"] = "Use Teleport to %s",
+    ["Take Flight Path to %s"] = "Take Flight Path to %s",
+    ["Take Blimp to %s"] = "Take Blimp to %s",
+    ["Walk to %s"] = "Walk to %s",
 
-L["Heroic 25"] = "Heroic 25"
-L["Heroic"] = "Heroic"
-L["Mythic"] = "Mythic"
+    ["Heroic 25"] = "Heroic 25",
+    ["Heroic"] = "Heroic",
+    ["Mythic"] = "Mythic",
 
-L["Unknown"] = "Unknown"
-L["Unknown Boss"] = "Unknown Boss"
+    ["Unknown"] = "Unknown",
+    ["Unknown Boss"] = "Unknown Boss",
 
-L["Run the instance on '%s' difficulty to collect all mounts."] = "Run the instance on '%s' difficulty to collect all mounts."
-L["Your Hearthstone is set to a different location!"] = "Your Hearthstone is set to a different location!"
+    ["Run the instance on '%s' difficulty to collect all mounts."] = "Run the instance on '%s' difficulty to collect all mounts.",
+    ["Your Hearthstone is set to a different location!"] = "Your Hearthstone is set to a different location!",
 
-L["Mount: %s"] = "Mount: %s"
-L["You have collected this mount."] = "You have collected this mount."
-L["This boss is dead."] = "This boss is dead."
-L["This boss is still alive."] = "This boss is still alive."
+    ["Mount: %s"] = "Mount: %s",
+    ["You have collected this mount."] = "You have collected this mount.",
+    ["This boss is dead."] = "This boss is dead.",
+    ["This boss is still alive."] = "This boss is still alive.",
 
-L["Auto-Skip Steps"] = "Auto-Skip Steps"
-L["Automatically skips steps that are already completed."] = "Automatically skips steps that are already completed."
+    ["Auto-Skip Steps"] = "Auto-Skip Steps",
+    ["Automatically skips steps that are already completed."] = "Automatically skips steps that are already completed.",
 
-L["Auto-Advance Steps"] = "Auto-Advance Steps"
-L["Automatically advances to the next step after completing the current one."] = "Automatically advances to the next step after completing the current one."
+    ["Auto-Advance Steps"] = "Auto-Advance Steps",
+    ["Automatically advances to the next step after completing the current one."] = "Automatically advances to the next step after completing the current one.",
 
-L["Instance location not found: '%s', please report it."] = "Instance location not found: '%s', please report it."
-L["NPC location not found for: '%s', please report it."] = "NPC location not found for: '%s', please report it."
-L["Item location not found for: '%s', please report it."] = "Item location not found for: '%s', please report it."
-L["Portal location not found for: '%s' in '%s', please report it."] = "Portal location not found for: '%s' in '%s', please report it."
-L["Teleport location not found for: '%s', please report it."] = "Teleport location not found for: '%s', please report it."
-L["Blimp location not found for: '%s', please report it."] = "Blimp location not found for: '%s', please report it."
-L["Flightmaster location not found for: '%s', please report it."] = "Flightmaster location not found for: '%s', please report it."
-L["Unknown action: '%s', please report it."] = "Unknown action: '%s', please report it."
+    ["Instance location not found: '%s', please report it."] = "Instance location not found: '%s', please report it.",
+    ["NPC location not found for: '%s', please report it."] = "NPC location not found for: '%s', please report it.",
+    ["Item location not found for: '%s', please report it."] = "Item location not found for: '%s', please report it.",
+    ["Portal location not found for: '%s' in '%s', please report it."] = "Portal location not found for: '%s' in '%s', please report it.",
+    ["Teleport location not found for: '%s', please report it."] = "Teleport location not found for: '%s', please report it.",
+    ["Blimp location not found for: '%s', please report it."] = "Blimp location not found for: '%s', please report it.",
+    ["Flightmaster location not found for: '%s', please report it."] = "Flightmaster location not found for: '%s', please report it.",
+    ["Unknown action: '%s', please report it."] = "Unknown action: '%s', please report it.",
 
-L["Map ID not found for: '%s', please report it."] = "Map ID not found for: '%s', please report it."
-L["Invalid map ID for: '%s', please report it."] = "Invalid map ID for: '%s', please report it."
-L["Invalid coordinates for: '%s', please report it."] = "Invalid coordinates for: '%s', please report it."
-L["Cannot set waypoint on map: '%s', please report it."] = "Cannot set waypoint on map: '%s', please report it."
+    ["Map ID not found for: '%s', please report it."] = "Map ID not found for: '%s', please report it.",
+    ["Failed to add TomTom waypoint for: '%s', please report it."] = "Failed to add TomTom waypoint for: '%s', please report it.",
+    ["Invalid map ID for: '%s', please report it."] = "Invalid map ID for: '%s', please report it.",
+    ["Invalid coordinates for: '%s', please report it."] = "Invalid coordinates for: '%s', please report it.",
+    ["Cannot set waypoint on map: '%s', please report it."] = "Cannot set waypoint on map: '%s', please report it.",
 
-L["Mount not found: '%s', please report it."] = "Mount not found: '%s', please report it."
+    ["Mount not found: '%s', please report it."] = "Mount not found: '%s', please report it.",
+    ["Item not found: '%s', please report it."] = "Item not found: '%s', please report it."
+}
 
-setmetatable(L, {__index=function(t,k) rawset(t, k, k); return k; end})
+setmetatable(MRP.L, {
+    __index = function(t, k)
+        rawset(t, k, k); return k;
+    end
+})

--- a/MRP_Locale.ruRU.lua
+++ b/MRP_Locale.ruRU.lua
@@ -1,100 +1,113 @@
-L = {}
+-- MRP_Locale.ruRU.lua
+local _, MRP = ...
+
+if (GetLocale() ~= "ruRU") then
+    return;
+end
+
 -- Translator ZamestoTV
-L["Mount Route Planner"] = "Mount Route Planner"
-L["Left-Click: Toggle Panel"] = "ЛКМ: Переключить панель"
-L["Drag: Move Button"] = "Перетаскивание: Переместить кнопку"
+MRP.L = {
+    ["Mount Route Planner"] = "Mount Route Planner",
+    ["Left-Click: Toggle Panel"] = "ЛКМ: Переключить панель",
+    ["Drag: Move Button"] = "Перетаскивание: Переместить кнопку",
 
-L["Mount Route Planner - Settings"] = "Mount Route Planner - Настройки"
-L["Use TomTom for waypoints"] = "Использовать TomTom для путевых точек"
-L["Enable this to use TomTom for waypoint navigation."] = "Включите, чтобы использовать TomTom для навигации по путевым точкам."
-L["This will create waypoints for each step in your route."] = "Это создаст путевые точки для каждого шага вашего маршрута."
-L["You must have TomTom installed for this to work."] = "Для работы необходимо установить TomTom."
-L["You can toggle this setting at any time."] = "Эту настройку можно переключать в любое время."
-L["Note: TomTom will print messages in chat occasionally."] = "Примечание: TomTom иногда будет выводить сообщения в чат."
+    ["Mount Route Planner - Settings"] = "Mount Route Planner - Настройки",
+    ["Use TomTom for waypoints"] = "Использовать TomTom для путевых точек",
+    ["Enable this to use TomTom for waypoint navigation."] = "Включите, чтобы использовать TomTom для навигации по путевым точкам.",
+    ["This will create waypoints for each step in your route."] = "Это создаст путевые точки для каждого шага вашего маршрута.",
+    ["You must have TomTom installed for this to work."] = "Для работы необходимо установить TomTom.",
+    ["You can toggle this setting at any time."] = "Эту настройку можно переключать в любое время.",
 
-L["|cff00ff00[MRP]|r TomTom usage is now: %s"] = "|cff00ff00[MRP]|r Использование TomTom теперь: %s"
-L["|cff00ff00ENABLED|r"] = "|cff00ff00ВКЛЮЧЕНО|r"
-L["|cffff0000DISABLED|r"] = "|cffff0000ОТКЛЮЧЕНО|r"
+    ["|cff00ff00[MRP]|r TomTom usage is now: %s"] = "|cff00ff00[MRP]|r Использование TomTom теперь: %s",
+    ["|cff00ff00ENABLED|r"] = "|cff00ff00ВКЛЮЧЕНО|r",
+    ["|cffff0000DISABLED|r"] = "|cffff0000ОТКЛЮЧЕНО|r",
+    ["|cffffd200Usage:|r"] = "|cffffd200Использование:|r",
 
-L["|cffffd200Usage:|r"] = "|cffffd200Использование:|r"
-L[" - /mrp → Toggle Mount Route Planner UI"] = " - /mrp → Переключить интерфейс Mount Route Planner"
-L[" - /mrp reset → Clears current progress and steps"] = " - /mrp reset → Очистить текущий прогресс и шаги"
-L[" - /mrp settings → Open addon settings"] = " - /mrp settings → Открыть настройки аддона"
-L[" - /mrp tomtom on|off → Enable or disable TomTom integration"] = " - /mrp tomtom on|off → Включить или отключить интеграцию с TomTom"
+    [" - /mrp → Toggle Mount Route Planner UI"] = " - /mrp → Переключить интерфейс Mount Route Planner",
+    [" - /mrp reset → Clears current progress and steps"] = " - /mrp reset → Очистить текущий прогресс и шаги",
+    [" - /mrp settings → Open addon settings"] = " - /mrp settings → Открыть настройки аддона",
+    [" - /mrp tomtom on|off → Enable or disable TomTom integration"] = " - /mrp tomtom on|off → Включить или отключить интеграцию с TomTom",
 
-L["Reset Steps"] = "Сбросить шаги"
-L["Clears current progress and steps"] = "Очищает текущий прогресс и шаги"
+    ["Reset Steps"] = "Сбросить шаги",
+    ["Clears current progress and steps"] = "Очищает текущий прогресс и шаги",
 
-L["Settings"] = "Настройки"
-L["Open the MRP settings panel"] = "Открыть панель настроек MRP"
+    ["Settings"] = "Настройки",
+    ["Open the MRP settings panel"] = "Открыть панель настроек MRP",
 
-L["No step loaded."] = "Шаг не загружен."
+    ["No step loaded."] = "Шаг не загружен.",
 
-L["<< Last"] = "<< Назад"
-L["Next >>"] = "Далее >>"
+    ["<< Last"] = "<< Назад",
+    ["Next >>"] = "Далее >>",
 
-L["Step 0 of 0"] = "Шаг 0 из 0"
-L["Step %d of %d"] = "Шаг %d из %d"
+    ["Step 0 of 0"] = "Шаг 0 из 0",
+    ["Step %d of %d"] = "Шаг %d из %d",
 
-L["Import Steps"] = "Импорт шагов"
-L["Paste Simple Armory Content"] = "Вставить содержимое Simple Armory"
+    ["Import Steps"] = "Импорт шагов",
+    ["Paste Simple Armory Content"] = "Вставить содержимое Simple Armory",
 
-L["Import"] = "Импорт"
-L["Prefill"] = "Предзаполнение"
-L["Cancel"] = "Отмена"
+    ["Import"] = "Импорт",
+    ["Prefill"] = "Предзаполнение",
+    ["Cancel"] = "Отмена",
 
-L["Automatically fills the input box with preset content based on your faction."] = "Автоматически заполняет поле ввода предустановленным содержимым в зависимости от вашей фракции."
-L["For optimal results import your character's data from Simple Armory."] = "Для оптимальных результатов импортируйте данные вашего персонажа из Simple Armory."
+    ["Automatically fills the input box with preset content based on your faction."] = "Автоматически заполняет поле ввода предустановленным содержимым в зависимости от вашей фракции.",
+    ["For optimal results import your character's data from Simple Armory."] = "Для оптимальных результатов импортируйте данные вашего персонажа из Simple Armory.",
 
-L["To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"] = "Чтобы импортировать содержимое Simple Armory, скопируйте всё содержимое по ссылке с simplearmory.com и вставьте его в поле ввода.\n\nОткройте в браузере:"
-L["Close"] = "Закрыть"
+    ["To import simple armory content, copy the whole content from your simplearmory.com link and paste it into the input box.\n\nOpen in your Browser:"] = "Чтобы импортировать содержимое Simple Armory, скопируйте всё содержимое по ссылке с simplearmory.com и вставьте его в поле ввода.\n\nОткройте в браузере:",
+    ["Close"] = "Закрыть",
 
-L["Run %s"] = "Пройти %s"
-L["Kill %s"] = "Убить %s"
-L["Use %s"] = "Использовать %s"
-L["Fly to %s"] = "Лететь в %s"
-L["Take Portal to %s"] = "Использовать портал в %s"
-L["Use Hearthstone to %s"] = "Использовать Камень возвращения в %s"
-L["Use Teleport to %s"] = "Использовать телепорт в %s"
-L["Take Flight Path to %s"] = "Использовать маршрут полёта в %s"
-L["Take Blimp to %s"] = "Использовать дирижабль в %s"
-L["Walk to %s"] = "Идти пешком в %s"
+    ["Run %s"] = "Пройти %s",
+    ["Kill %s"] = "Убить %s",
+    ["Use %s"] = "Использовать %s",
+    ["Fly to %s"] = "Лететь в %s",
+    ["Take Portal to %s"] = "Использовать портал в %s",
+    ["Use Hearthstone to %s"] = "Использовать Камень возвращения в %s",
+    ["Use Teleport to %s"] = "Использовать телепорт в %s",
+    ["Take Flight Path to %s"] = "Использовать маршрут полёта в %s",
+    ["Take Blimp to %s"] = "Использовать дирижабль в %s",
+    ["Walk to %s"] = "Идти пешком в %s",
 
-L["Heroic 25"] = "Героический 25"
-L["Heroic"] = "Героический"
-L["Mythic"] = "Эпохальный"
+    ["Heroic 25"] = "Героический 25",
+    ["Heroic"] = "Героический",
+    ["Mythic"] = "Эпохальный",
 
-L["Unknown"] = "Неизвестно"
-L["Unknown Boss"] = "Неизвестный босс"
+    ["Unknown"] = "Неизвестно",
+    ["Unknown Boss"] = "Неизвестный босс",
 
-L["Run the instance on '%s' difficulty to collect all mounts."] = "Пройдите подземелье на сложности '%s', чтобы собрать все маунты."
-L["Your Hearthstone is set to a different location!"] = "Ваш Камень возвращения настроен на другое место!"
+    ["Run the instance on '%s' difficulty to collect all mounts."] = "Пройдите подземелье на сложности '%s', чтобы собрать все маунты.",
+    ["Your Hearthstone is set to a different location!"] = "Ваш Камень возвращения настроен на другое место!",
 
-L["Mount: %s"] = "Маунт: %s"
-L["You have collected this mount."] = "Вы получили этого маунта."
-L["This boss is dead."] = "Этот босс мёртв."
-L["This boss is still alive."] = "Этот босс всё ещё жив."
+    ["Mount: %s"] = "Маунт: %s",
+    ["You have collected this mount."] = "Вы получили этого маунта.",
+    ["This boss is dead."] = "Этот босс мёртв.",
+    ["This boss is still alive."] = "Этот босс всё ещё жив.",
 
-L["Auto-Skip Steps"] = "Автопропуск шагов"
-L["Automatically skips steps that are already completed."] = "Автоматически пропускает уже завершённые шаги."
+    ["Auto-Skip Steps"] = "Автопропуск шагов",
+    ["Automatically skips steps that are already completed."] = "Автоматически пропускает уже завершённые шаги.",
 
-L["Auto-Advance Steps"] = "Автопродвижение шагов"
-L["Automatically advances to the next step after completing the current one."] = "Автоматически переходит к следующему шагу после завершения текущего."
+    ["Auto-Advance Steps"] = "Автопродвижение шагов",
+    ["Automatically advances to the next step after completing the current one."] = "Автоматически переходит к следующему шагу после завершения текущего.",
 
-L["Instance location not found: '%s', please report it."] = "Местоположение подземелья не найдено: '%s', пожалуйста, сообщите об этом."
-L["NPC location not found for: '%s', please report it."] = "Местоположение НПС не найдено для: '%s', пожалуйста, сообщите об этом."
-L["Item location not found for: '%s', please report it."] = "Местоположение предмета не найдено для: '%s', пожалуйста, сообщите об этом."
-L["Portal location not found for: '%s' in '%s', please report it."] = "Местоположение портала не найдено для: '%s' в '%s', пожалуйста, сообщите об этом."
-L["Teleport location not found for: '%s', please report it."] = "Местоположение телепорта не найдено для: '%s', пожалуйста, сообщите об этом."
-L["Blimp location not found for: '%s', please report it."] = "Местоположение дирижабля не найдено для: '%s', пожалуйста, сообщите об этом."
-L["Flightmaster location not found for: '%s', please report it."] = "Местоположение мастера полётов не найдено для: '%s', пожалуйста, сообщите об этом."
-L["Unknown action: '%s', please report it."] = "Неизвестное действие: '%s', пожалуйста, сообщите об этом."
+    ["Instance location not found: '%s', please report it."] = "Местоположение подземелья не найдено: '%s', пожалуйста, сообщите об этом.",
+    ["NPC location not found for: '%s', please report it."] = "Местоположение НПС не найдено для: '%s', пожалуйста, сообщите об этом.",
+    ["Item location not found for: '%s', please report it."] = "Местоположение предмета не найдено для: '%s', пожалуйста, сообщите об этом.",
+    ["Portal location not found for: '%s' in '%s', please report it."] = "Местоположение портала не найдено для: '%s' в '%s', пожалуйста, сообщите об этом.",
+    ["Teleport location not found for: '%s', please report it."] = "Местоположение телепорта не найдено для: '%s', пожалуйста, сообщите об этом.",
+    ["Blimp location not found for: '%s', please report it."] = "Местоположение дирижабля не найдено для: '%s', пожалуйста, сообщите об этом.",
+    ["Flightmaster location not found for: '%s', please report it."] = "Местоположение мастера полётов не найдено для: '%s', пожалуйста, сообщите об этом.",
+    ["Unknown action: '%s', please report it."] = "Неизвестное действие: '%s', пожалуйста, сообщите об этом.",
 
-L["Map ID not found for: '%s', please report it."] = "ID карты не найден для: '%s', пожалуйста, сообщите об этом."
-L["Invalid map ID for: '%s', please report it."] = "Недействительный ID карты для: '%s', пожалуйста, сообщите об этом."
-L["Invalid coordinates for: '%s', please report it."] = "Недействительные координаты для: '%s', пожалуйста, сообщите об этом."
-L["Cannot set waypoint on map: '%s', please report it."] = "Невозможно установить точку маршрута на карте: '%s', пожалуйста, сообщите об этом."
+    ["Map ID not found for: '%s', please report it."] = "ID карты не найден для: '%s', пожалуйста, сообщите об этом.",
+    ["Failed to add TomTom waypoint for: '%s', please report it."] = "Не удалось добавить путевую точку TomTom для: '%s', пожалуйста, сообщите об этом.",
+    ["Invalid map ID for: '%s', please report it."] = "Недействительный ID карты для: '%s', пожалуйста, сообщите об этом.",
+    ["Invalid coordinates for: '%s', please report it."] = "Недействительные координаты для: '%s', пожалуйста, сообщите об этом.",
+    ["Cannot set waypoint on map: '%s', please report it."] = "Невозможно установить точку маршрута на карте: '%s', пожалуйста, сообщите об этом.",
 
-L["Mount not found: '%s', please report it."] = "Маунт не найден: '%s', пожалуйста, сообщите об этом."
+    ["Mount not found: '%s', please report it."] = "Маунт не найден: '%s', пожалуйста, сообщите об этом.",
+    ["Item not found: '%s', please report it."] = "Предмет не найден: '%s', пожалуйста, сообщите об этом."
+}
 
-setmetatable(L, {__index=function(t,k) rawset(t, k, k); return k; end})
+setmetatable(MRP.L, {
+    __index = function(t, k)
+        rawset(t, k, k); return k;
+    end
+})

--- a/MRP_Minimap.lua
+++ b/MRP_Minimap.lua
@@ -1,5 +1,7 @@
-MRP = MRP or {}
-MRP.UI = MRP.UI or {}
+-- MRP_Minimap.lua
+local _, MRP = ...
+
+local L = MRP.L
 
 local button = CreateFrame("Button", "MRPMinimapButton", Minimap)
 button:SetSize(28, 28)

--- a/MRP_Prefills.lua
+++ b/MRP_Prefills.lua
@@ -1,3 +1,4 @@
+-- MRP_Prefills.lua
 local alliance = nil
 local horde = nil
 
@@ -271,7 +272,7 @@ function MRP_GetAlliancePrefill()
         a = a .. "\n"
         alliance = a
     end
-    
+
     return alliance
 end
 
@@ -561,6 +562,6 @@ function MRP_GetHordePrefill()
         h = h .. "\n"
         horde = h
     end
-    
+
     return horde
 end

--- a/MountRoutePlanner.toc
+++ b/MountRoutePlanner.toc
@@ -1,7 +1,7 @@
 ## Interface: 110107
 ## Title: Mount Route Planner (MRP)
 ## Author: Deathwing
-## Version: v0.1.0
+## Version: v0.3.0
 ## LoadOnDemand: 0
 ## License: All Rights Reserved
 ## IconTexture: Interface\AddOns\MountRoutePlanner\MRP.tga
@@ -21,10 +21,12 @@
 ## Category-zhCN: 战团藏品
 ## Category-zhTW: 戰隊收藏
 
-## X-Localizations: enUS, enGB
+## X-Localizations: enUS, enGB, deDE, ruRU
 ## X-CompatibleLocales: enUS, enGB, deDE, frFR, esES, esMX, itIT, ptBR, ruRU, koKR, zhCN, zhTW
 
 MRP_Locale.enUS.lua
+MRP_Locale.deDE.lua
+MRP_Locale.ruRU.lua
 
 MRP_DB.lua
 MRP_Data.lua

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Mount Route Planner
+Plan your mount farming route using SimpleArmory data with waypoint integration and smart step skipping.
+
+## Supported Console Commands
+
+### /mrp
+
+Toggles Mount Route Planner UI
+
+### /mrp reset
+
+Clears current progress and steps
+
+### /mrp settings
+
+Opens Mount Route Planner settings
+
+### /mrp tomtom <on|off>
+
+Enables or disables TomTom integration


### PR DESCRIPTION
Sorry I accidentally deleted the fork

Hello,

this PR fixes a critical Lua error in `MRP_Parser.lua` that occurs when pasting routes containing empty lines or multiple notes for a single boss.

**The Problem:**

The parser would crash with the following error:
`attempt to index field '?' (a nil value)`

This was caused by two issues:
* Empty lines in the pasted route text were not ignored and were incorrectly treated as "empty notes".
* The logic for assigning notes to rewards (boss/mount) was flawed. It used an incorrect counter, leading to an out-of-bounds index error if there were more note lines than boss lines in a given step.

**The Solution:**

The `ParseSteps` function has been refactored to address these issues:
* The parser now **completely ignores empty lines** or lines containing only whitespace.
* The **note assignment logic has been fixed**. Notes are now reliably assigned to the last found boss/reward, rather than relying on a faulty counter. This also allows for multiple note lines for a single boss.

These changes make the parser much more robust and allow for a smooth import of routes, such as those provided by Simple Armory.

Additional Context: Further testing revealed that this issue is browser-dependent. Text copied from Firefox preserves the empty newlines that trigger the bug, while text copied from Microsoft Edge seems to be sanitized, which is why it worked by coincidence. This fix ensures that the parser works reliably, regardless of the user's browser.

Thanks for the great addon!