### PR TITLE
Function: Automatic warning if the difficulty level is incorrect

### DIFF
--- a/MRP_Locale.deDE.lua
+++ b/MRP_Locale.deDE.lua
@@ -102,7 +102,10 @@ MRP.L = {
     ["Cannot set waypoint on map: '%s', please report it."] = "Kann keinen Wegpunkt auf der Karte setzen: '%s', bitte melde es.",
 
     ["Mount not found: '%s', please report it."] = "Reittier nicht gefunden: '%s', bitte melde es.",
-    ["Item not found: '%s', please report it."] = "Gegenstand nicht gefunden: '%s', bitte melde es."
+    ["Item not found: '%s', please report it."] = "Gegenstand nicht gefunden: '%s', bitte melde es.",
+
+    ["Wrong Difficulty"] = "Falsche Schwierigkeit",
+    ["Please switch to '%s'"] = "Bitte auf '%s' umstellen"
 }
 
 setmetatable(MRP.L, {

--- a/MRP_Locale.enUS.lua
+++ b/MRP_Locale.enUS.lua
@@ -98,7 +98,10 @@ MRP.L = {
     ["Cannot set waypoint on map: '%s', please report it."] = "Cannot set waypoint on map: '%s', please report it.",
 
     ["Mount not found: '%s', please report it."] = "Mount not found: '%s', please report it.",
-    ["Item not found: '%s', please report it."] = "Item not found: '%s', please report it."
+    ["Item not found: '%s', please report it."] = "Item not found: '%s', please report it.",
+
+    ["Wrong Difficulty"] = "Wrong Difficulty",
+    ["Please switch to '%s'"] = "Please switch to '%s'"
 }
 
 setmetatable(MRP.L, {

--- a/MRP_UI.lua
+++ b/MRP_UI.lua
@@ -640,3 +640,38 @@ f:SetScript("OnEvent", function()
     toggle:SetChecked(MRP_DB.autoSkip)
     autoAdvanceToggle:SetChecked(MRP_DB.autoAdvance)
 end)
+
+local warningFrame = CreateFrame("Frame", "MRPDifficultyWarningFrame", UIParent, "BackdropTemplate")
+warningFrame:SetSize(500, 100)
+warningFrame:SetPoint("TOP", UIParent, "TOP", 0, -150)
+warningFrame:SetFrameStrata("HIGH")
+warningFrame:SetBackdrop({
+    bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+    edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+    tile = true, tileSize = 32, edgeSize = 32,
+    insets = { left = 11, right = 12, top = 12, bottom = 11 }
+})
+warningFrame:SetBackdropColor(0.8, 0, 0, 0.9)
+warningFrame:Hide()
+
+-- Main text of the warning
+warningFrame.title = warningFrame:CreateFontString(nil, "OVERLAY", "GameFont_Gigantic")
+warningFrame.title:SetPoint("TOP", warningFrame, "TOP", 0, -25)
+warningFrame.title:SetTextColor(1, 0.82, 0)
+warningFrame.title:SetText(L["Wrong Difficulty"])
+
+-- Subtitle with the instruction
+warningFrame.subText = warningFrame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+warningFrame.subText:SetPoint("TOP", warningFrame.title, "BOTTOM", 0, -8)
+warningFrame.subText:SetTextColor(1, 1, 1)
+warningFrame.subText:SetText(L["Please switch to '%s'"])
+
+-- Functions for displaying and hiding the window
+function UI:ShowDifficultyWarning(requiredDifficultyText)
+    warningFrame.subText:SetText(string.format(L["Please switch to '%s'"], requiredDifficultyText))
+    warningFrame:Show()
+end
+
+function UI:HideDifficultyWarning()
+    warningFrame:Hide()
+end


### PR DESCRIPTION
Hello!

This pull request adds a new, major quality-of-life feature: an automatic warning that appears when a player enters an instance with the wrong difficulty set.

**Feature Purpose:**
This feature prevents players from accidentally clearing an entire raid on the wrong difficulty, thereby losing their weekly chance at a mount. If the current difficulty does not match the requirements for a mount in the active step, a large, centered warning appears on the screen.

**Technical Implementation & Changes:**

1.  **`MRP.lua`:**
    * The `StepWatcher` now listens for all relevant zone change events (`ZONE_CHANGED_INDOORS`, `ZONE_CHANGED_NEW_AREA`, etc.) to reliably trigger the check.
    * Upon entering an instance, new logic compares the currently set difficulty with the requirements parsed from the route's notes.
    * The `MRP_MatchesDifficulty` function has been refactored to use the correct difficulty IDs and be more robust.
    * You can also view the list of difficulty level IDs here: https://wowpedia.fandom.com/wiki/DifficultyID

2.  **`MRP_UI.lua`:**
    * A new, large warning frame (`MRPDifficultyWarningFrame`) has been added to the end of the file.
    * This frame is hidden by default and is only shown when triggered by the logic in `MRP.lua`.
    * The text inside the warning frame is centered for better readability.

3.  **`MRP_Locale.enUS.lua` & `MRP_Locale.deDE.lua`:**
    * The new strings for the warning (`Wrong Difficulty` and `Please switch to '%s'`) have been added to the localization files to fully support this feature.

This feature should make the addon even more helpful for many players. Thank you for your work!

![{57B2708E-0401-4794-9784-4415B12266C7}](https://github.com/user-attachments/assets/f49a003d-e970-4d20-8205-c47648b35ae9)
